### PR TITLE
Remove use of 'using namespace' in header files

### DIFF
--- a/src/internalizer.h
+++ b/src/internalizer.h
@@ -1,16 +1,12 @@
 #pragma once
 
-#include <unordered_map>
-#include <map>
-#include <set>
-#include <vector>
-#include <memory>
-#include <functional>
 #include <assert.h>
-
-using namespace std;
-
-
+#include <functional>
+#include <map>
+#include <memory>
+#include <set>
+#include <unordered_map>
+#include <vector>
 
 namespace mtidd
 {
@@ -18,12 +14,12 @@ namespace mtidd
   // takes, stores object, and give an int reference
   // the goal is to put all the object in a single place and not leak memory
   // implicitely this also gives an order on the stored elements
-  template< class T, class Hash = hash<T>, class Equal = equal_to<T> >
+  template< class T, class Hash = std::hash<T>, class Equal = std::equal_to<T> >
   class internalizer
   {
   private:
-    unordered_map<T, int, Hash, Equal> by_value;
-    vector<T> by_index;
+    std::unordered_map<T, int, Hash, Equal> by_value;
+    std::vector<T> by_index;
   public:
 
     int index(T const & v) const {
@@ -56,9 +52,9 @@ namespace mtidd
       }
     }
 
-    void permute(map<int, int> const & permutation) {
+    void permute(std::map<int, int> const & permutation) {
       // update by_index
-      vector<T> old_indices = by_index; // FIXME twice the memory during this method...
+      std::vector<T> old_indices = by_index; // FIXME twice the memory during this method...
       by_index.clear();
       auto n = old_indices.size();
       by_index.resize(n);
@@ -84,7 +80,7 @@ namespace mtidd
     }
 
     //this invalidates the indices
-    void clear(set<T> const & values_to_keep) {
+    void clear(std::set<T> const & values_to_keep) {
       clear();
       for (auto it = values_to_keep.begin(); it != values_to_keep.end(); ++it) {
         internalize(*it);

--- a/src/interval.h
+++ b/src/interval.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#include <tuple>
-#include <limits>
 #include <iostream>
-
-using namespace std;
+#include <limits>
+#include <tuple>
 
 namespace mtidd
 {
@@ -17,13 +15,13 @@ namespace mtidd
 
   interval_boundary complement(interval_boundary b);
 
-  ostream & operator<<(ostream & out, const interval_boundary& b);
+  std::ostream & operator<<(std::ostream & out, const interval_boundary& b);
 
   ///////////////////
   // half interval //
   ///////////////////
 
-  typedef tuple<double,interval_boundary> half_interval;
+  typedef std::tuple<double,interval_boundary> half_interval;
 
   // lhs is the right/end of an interval
   // rhs is the left/start of an interval
@@ -38,17 +36,17 @@ namespace mtidd
   // rhs is the left/start of an interval
   const half_interval& min(const half_interval& lhs, const half_interval& rhs);
 
-  ostream & operator<<(ostream & out, const half_interval& i);
+  std::ostream & operator<<(std::ostream & out, const half_interval& i);
 
   // sentinel nodes
-  const half_interval lower_sentinel = make_tuple<double, interval_boundary>(-numeric_limits<double>::infinity(), Open);
-  const half_interval upper_sentinel = make_tuple<double, interval_boundary>( numeric_limits<double>::infinity(), Open);
+  const half_interval lower_sentinel = std::make_tuple<double, interval_boundary>(-std::numeric_limits<double>::infinity(), Open);
+  const half_interval upper_sentinel = std::make_tuple<double, interval_boundary>( std::numeric_limits<double>::infinity(), Open);
 
   //////////////
   // interval //
   //////////////
 
-  typedef tuple<double,interval_boundary,double,interval_boundary> interval;
+  typedef std::tuple<double,interval_boundary,double,interval_boundary> interval;
 
   bool is_empty(const interval& i);
 
@@ -60,6 +58,6 @@ namespace mtidd
 
   half_interval ends(const interval& i);
 
-  ostream & operator<<(ostream & out, const interval& i);
+  std::ostream & operator<<(std::ostream & out, const interval& i);
 
 }

--- a/src/lattice.h
+++ b/src/lattice.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+
 #include "utils.h"
 
 namespace mtidd

--- a/src/utils.h
+++ b/src/utils.h
@@ -2,11 +2,9 @@
 
 #include <cstdint>
 
-using namespace std;
-
 namespace mtidd
 {
-  
+
   uint64_t rotl64 ( uint64_t x, int8_t r );
 
   uint64_t combine_two_hashes( uint64_t x, uint64_t y );


### PR DESCRIPTION
The use of `using namespace` in a library's header file has a global effect. It pollutes the name resolution of the user code (which includes the library). As a result, it is considered as a bad practice. 

Reference: https://stackoverflow.com/questions/1452721/why-is-using-name
space-std-considered-bad-practice