### PR TITLE
Remove src/test from installation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,5 +78,6 @@ endif()
 # not really necessary in this example. Use "sudo make install" to apply
 install(TARGETS mtidd DESTINATION lib)
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/" DESTINATION include/mtidd
-        FILES_MATCHING PATTERN "*.h")
+        FILES_MATCHING PATTERN "*.h"
+                       PATTERN "test" EXCLUDE)
 


### PR DESCRIPTION
The current `install` command does:
```
...
-- Installing: /Users/soonhok/tmp/mtidd/include/mtidd/test
...
```

This patch removes the entry.